### PR TITLE
.net10 support and drop .net6 and .net7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
     tags: ['v*.*.*']
     paths-ignore: ['**/*.md', '**/*.png', '**/*.txt']
   pull_request:
-    branches: [dev, main]
+    branches: [main]
     types: [opened, reopened, edited]
     paths-ignore: ['**/*.md', '**/*.png', '**/*.txt']
 
@@ -19,16 +19,15 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: |
-          6.0.x
-          7.0.x
           8.0.x
           9.0.x
+          10.0.x
 
     - name: Restore
       run: dotnet restore

--- a/.github/workflows/pack_and_deploy.yml
+++ b/.github/workflows/pack_and_deploy.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         sparse-checkout: |
           .github
@@ -24,13 +24,12 @@ jobs:
           build
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: |
-          6.0.x
-          7.0.x
           8.0.x
           9.0.x
+          10.0.x
 
     - name: Pack & Push to NuGet
       shell: pwsh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
     types:
       - completed
   pull_request:
-    branches: [dev, main]
+    branches: [main]
     types: [opened, reopened, edited]
     paths-ignore: ['**/*.md', '**/*.png', '**/*.txt']
 
@@ -20,16 +20,15 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: |
-          6.0.x
-          7.0.x
           8.0.x
           9.0.x
+          10.0.x
 
     - name: Test
       run: dotnet test ${{ env.TEST_PROJECTS_PATH }} --configuration ${{ env.CONFIGURATION }}

--- a/README.md
+++ b/README.md
@@ -37,28 +37,13 @@
 | [![NSwag Nuget Version]](https://www.nuget.org/packages/NSwag.AspNetCore.Themes/) | Customize the style for [NSwag.AspNetCore] |
 
 
-> [!WARNING]
-> If you're upgrading from 1.0.0 to 2.x, there's a breaking change to be aware of: **NoJsModernStyle is no more available, use ModernStyle instead**. See the [release notes](https://github.com/teociaps/SwaggerUI.Themes/releases/tag/v2.0.0) for details.
-
-
 ## Features
 
 - **[Predefined Themes](https://github.com/teociaps/SwaggerUI.Themes/wiki/Predefined-Themes)**: choose from a variety of themes to customize the Swagger documentation interface. Options include a default style that preserves the classic Swagger UI look, along with fresh, modern styles.
 
 - **[Custom Styles](https://github.com/teociaps/SwaggerUI.Themes/wiki/Custom-Styles)**: design your own Swagger UI style by either extending the classic or modern base styles or creating a completely new look.
 
-- 🆕 **[Advanced Options](https://github.com/teociaps/SwaggerUI.Themes/wiki/Advanced-Options)**: access expanded features with both classic and modern styles for an optimized API documentation experience.
-
-
-## Supported .NET Versions
-| Version | Status |
-| ------- | ------ |
-| .NET 6  | ![Badge](https://img.shields.io/badge/Status-Supported-brightgreen) |
-| .NET 7  | ![Badge](https://img.shields.io/badge/Status-Out%20of%20Support*-orange) |
-| .NET 8  | ![Badge](https://img.shields.io/badge/Status-Supported-brightgreen) |
-| .NET 9  | ![Badge](https://img.shields.io/badge/Status-Supported-brightgreen) |
-
-___* Still available but it won't receive any update!___
+- **[Advanced Options](https://github.com/teociaps/SwaggerUI.Themes/wiki/Advanced-Options)**: access expanded features with both classic and modern styles for an optimized API documentation experience.
 
 
 ## Contributing
@@ -66,6 +51,9 @@ ___* Still available but it won't receive any update!___
 If you have any suggestions, bug reports, or contributions, feel free to open an [issue](https://github.com/teociaps/SwaggerUI.Themes/issues) or submit a [pull request](https://github.com/teociaps/SwaggerUI.Themes/pulls).
 
 
+## Release
+
+See the [release notes](https://github.com/teociaps/SwaggerUI.Themes/releases) for details.
 
 
 

--- a/build/Common.Core.props
+++ b/build/Common.Core.props
@@ -1,8 +1,8 @@
 <Project>
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
-    <LangVersion>13.0</LangVersion>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <LangVersion>14.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace />
   </PropertyGroup>

--- a/build/NuGet.props
+++ b/build/NuGet.props
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <IsPackable>true</IsPackable>
     <Authors>Matteo Ciapparelli</Authors>
-    <Copyright>Copyright © 2024 Matteo Ciapparelli</Copyright>
+    <Copyright>Copyright © 2024-present Matteo Ciapparelli</Copyright>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/teociaps/SwaggerUI.Themes</PackageProjectUrl>
     <RepositoryUrl>https://github.com/teociaps/SwaggerUI.Themes.git</RepositoryUrl>

--- a/package-readme.md
+++ b/package-readme.md
@@ -3,12 +3,6 @@
 Change style to your API documentation in ASP.NET Core applications.
 
 
-> ⚠️ **Warning** ⚠️
->
-> If you're upgrading from 1.0.0 to 2.x, there's a breaking change to be aware of: **NoJsModernStyle is no more available, use ModernStyle instead**.
-> See the [release notes](https://github.com/teociaps/SwaggerUI.Themes/releases/tag/v2.0.0) for details.
-
-
 ## Features
 - __New Themes__: Choose from a variety of themes to customize the Swagger documentation interface. Options include a default style that preserves the classic Swagger UI look, along with fresh, modern styles.
 - __Advanced Options__: Access expanded features with both classic and modern styles for an optimized API documentation experience.
@@ -16,4 +10,4 @@ Change style to your API documentation in ASP.NET Core applications.
 - __Easy Integration__: and add style parameters to the existing Swagger UI setup for a seamless upgrade.
 
 
-Learn more [here](https://github.com/teociaps/SwaggerUI.Themes).
+[Getting started](https://github.com/teociaps/SwaggerUI.Themes/wiki/Getting-Started)!

--- a/samples/Sample.AspNetCore.SwaggerUI.NSwag/Endpoints.cs
+++ b/samples/Sample.AspNetCore.SwaggerUI.NSwag/Endpoints.cs
@@ -1,11 +1,5 @@
 ﻿using Models;
 
-#if NET6_0
-
-using NSwag.Annotations;
-
-#endif
-
 namespace Sample.AspNetCore.SwaggerUI.NSwag;
 
 internal static class Endpoints
@@ -44,12 +38,7 @@ internal static class Endpoints
     private static RouteHandlerBuilder WithInfo(this RouteHandlerBuilder builder)
     {
         return builder
-#if NET7_0_OR_GREATER
             .WithSummary("Summary")
-            .WithDescription("Description Test")
-            .WithOpenApi();
-#else
-            .WithMetadata(new OpenApiOperationAttribute(summary: "Summary", description: "Description Test"));
-#endif
+            .WithDescription("Description Test");
     }
 }

--- a/samples/Sample.AspNetCore.SwaggerUI.NSwag/Sample.AspNetCore.SwaggerUI.NSwag.csproj
+++ b/samples/Sample.AspNetCore.SwaggerUI.NSwag/Sample.AspNetCore.SwaggerUI.NSwag.csproj
@@ -8,16 +8,16 @@
     <OpenApiGeneratorDocumentsOnBuild>false</OpenApiGeneratorDocumentsOnBuild>
   </PropertyGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.11" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.11" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.20" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Sample.AspNetCore.SwaggerUI.NSwag/Sample.AspNetCore.SwaggerUI.NSwag.csproj
+++ b/samples/Sample.AspNetCore.SwaggerUI.NSwag/Sample.AspNetCore.SwaggerUI.NSwag.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <Import Project="..\..\build\Common.Core.props" />
 
@@ -7,6 +7,10 @@
     <OpenApiGenerateDocuments>false</OpenApiGenerateDocuments>
     <OpenApiGeneratorDocumentsOnBuild>false</OpenApiGeneratorDocumentsOnBuild>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NSwag.AspNetCore" Version="14.6.2" />
+  </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />

--- a/samples/Sample.AspNetCore.SwaggerUI.Swashbuckle/Endpoints.cs
+++ b/samples/Sample.AspNetCore.SwaggerUI.Swashbuckle/Endpoints.cs
@@ -1,11 +1,5 @@
 ﻿using Models;
 
-#if NET6_0
-
-using Swashbuckle.AspNetCore.Annotations;
-
-#endif
-
 namespace Sample.AspNetCore.SwaggerUI.Swashbuckle;
 
 internal static class Endpoints
@@ -44,12 +38,7 @@ internal static class Endpoints
     private static RouteHandlerBuilder WithInfo(this RouteHandlerBuilder builder)
     {
         return builder
-#if NET7_0_OR_GREATER
             .WithSummary("Summary")
-            .WithDescription("Description Test")
-            .WithOpenApi();
-#else
-            .WithMetadata(new SwaggerOperationAttribute(summary: "Summary", description: "Description Test"));
-#endif
+            .WithDescription("Description Test");
     }
 }

--- a/samples/Sample.AspNetCore.SwaggerUI.Swashbuckle/Program.cs
+++ b/samples/Sample.AspNetCore.SwaggerUI.Swashbuckle/Program.cs
@@ -12,6 +12,7 @@ var app = builder.Build();
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
+    //string inlineStyle = "body { background-color: #000; }";
     //app.UseSwaggerUI(CustomModernStyle.CustomModern, c => c.DocumentTitle = "Sample Title");
     //app.UseSwaggerUI(Assembly.GetExecutingAssembly(), "modern.custom.css", c =>
     app.UseSwaggerUI(ModernStyle.Dark, c =>

--- a/samples/Sample.AspNetCore.SwaggerUI.Swashbuckle/Sample.AspNetCore.SwaggerUI.Swashbuckle.csproj
+++ b/samples/Sample.AspNetCore.SwaggerUI.Swashbuckle/Sample.AspNetCore.SwaggerUI.Swashbuckle.csproj
@@ -8,23 +8,20 @@
     <OpenApiGeneratorDocumentsOnBuild>false</OpenApiGeneratorDocumentsOnBuild>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.11" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.11" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.20" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="7.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Sample.AspNetCore.SwaggerUI.Swashbuckle/SwaggerGenConfigurer.cs
+++ b/samples/Sample.AspNetCore.SwaggerUI.Swashbuckle/SwaggerGenConfigurer.cs
@@ -1,13 +1,7 @@
 ﻿#pragma warning disable S1075 // URIs should not be hardcoded - Done for testing purposes
 
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
-
-#if NET6_0 || NET7_0
-
-using Swashbuckle.AspNetCore.Annotations;
-
-#endif
 
 namespace Sample.AspNetCore.SwaggerUI.Swashbuckle;
 
@@ -15,9 +9,6 @@ internal static class SwaggerGenConfigurer
 {
     internal static void Configure(this SwaggerGenOptions options)
     {
-#if NET6_0 || NET7_0
-        options.EnableAnnotations();
-#endif
         options.SwaggerDoc("v1", new OpenApiInfo
         {
             Version = "v1",
@@ -35,32 +26,16 @@ internal static class SwaggerGenConfigurer
                 Url = new Uri("https://example.com/license")
             }
         });
-        options.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+        options.AddSecurityDefinition("bearer", new OpenApiSecurityScheme
         {
-            Description = @"JWT Authorization header using the Bearer scheme.
-                          Enter 'Bearer ' and then your token in the text input below.
-                          Example: 'Bearer 12345abcdef'",
-            Name = "Authorization",
-            In = ParameterLocation.Header,
-            Type = SecuritySchemeType.ApiKey,
-            Scheme = "Bearer"
+            Type = SecuritySchemeType.Http,
+            Scheme = "bearer",
+            BearerFormat = "JWT",
+            Description = "JWT Authorization header using the Bearer scheme."
         });
-        options.AddSecurityRequirement(new OpenApiSecurityRequirement()
+        options.AddSecurityRequirement(document => new OpenApiSecurityRequirement
         {
-            {
-                new OpenApiSecurityScheme
-                {
-                    Reference = new OpenApiReference
-                    {
-                        Type = ReferenceType.SecurityScheme,
-                        Id = "Bearer"
-                    },
-                    Scheme = "oauth2",
-                    Name = "Bearer",
-                    In = ParameterLocation.Header,
-                },
-                new List<string>()
-            }
+            [new OpenApiSecuritySchemeReference("bearer", document)] = []
         });
     }
 }

--- a/src/AspNetCore.Swagger.Themes.Common/AspNetCore/Swagger/Themes/BaseStyle.cs
+++ b/src/AspNetCore.Swagger.Themes.Common/AspNetCore/Swagger/Themes/BaseStyle.cs
@@ -32,11 +32,7 @@ public abstract class BaseStyle
     /// <returns>The style name.</returns>
     protected virtual string GetStyleName()
     {
-#if NET6_0_OR_GREATER
         return char.ToUpper(FileName[0]) + FileName[1..FileName.LastIndexOf('.')];
-#else
-        return char.ToUpper(FileName[0]) + FileName.Substring(1, FileName.LastIndexOf('.'));
-#endif
     }
 
     private static void CheckFileNameExtension(string fileName)

--- a/src/AspNetCore.Swagger.Themes.Common/AspNetCore/Swagger/Themes/ModernStyle.cs
+++ b/src/AspNetCore.Swagger.Themes.Common/AspNetCore/Swagger/Themes/ModernStyle.cs
@@ -46,10 +46,6 @@ public class ModernStyle : BaseStyle
     /// <inheritdoc/>
     protected override string GetStyleName()
     {
-#if NET6_0_OR_GREATER
         return char.ToUpper(FileName[0]) + FileName[1..FileName.LastIndexOf('.')].Replace('.', ' ');
-#else
-        return char.ToUpper(FileName[0]) + FileName.Substring(1, FileName.LastIndexOf('.')).Replace('.', ' ');
-#endif
     }
 }

--- a/src/AspNetCore.SwaggerUI.Themes/AspNetCore.SwaggerUI.Themes.csproj
+++ b/src/AspNetCore.SwaggerUI.Themes/AspNetCore.SwaggerUI.Themes.csproj
@@ -18,13 +18,13 @@
       Change theme to your Swagger API documentation in ASP.NET Core applications.
     </Description>
     <PackageTags>
-      extension;aspnetcore;swagger;swagger-ui;themes;dark-theme;modern
+      extension;aspnetcore;swagger;swagger-ui;themes;ui;dark-theme;modern
     </PackageTags>
     <IncludeBuildOutput>true</IncludeBuildOutput>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.0.1" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNetCore.SwaggerUI.Themes/Microsoft/AspNetCore/Builder/SwaggerUIOptionsExtensions.cs
+++ b/src/AspNetCore.SwaggerUI.Themes/Microsoft/AspNetCore/Builder/SwaggerUIOptionsExtensions.cs
@@ -16,15 +16,15 @@ public static class SwaggerUIOptionsExtensions
     /// <see cref="EnablePinnableTopbar(SwaggerUIOptions)"/>
     /// </item>
     /// <item>
-    /// Back to top button
+    /// Back to top button:
     /// <see cref="ShowBackToTopButton(SwaggerUIOptions)"/>
     /// </item>
     /// <item>
-    /// Sticky operations
+    /// Sticky operations:
     /// <see cref="EnableStickyOperations(SwaggerUIOptions)"/>
     /// </item>
     /// <item>
-    /// Expand or collapse all operations
+    /// Expand or collapse all operations:
     /// <see cref="EnableExpandOrCollapseAllOperations(SwaggerUIOptions)"/>
     /// </item>
     /// </list>

--- a/src/AspNetCore.SwaggerUI.Themes/readme.txt
+++ b/src/AspNetCore.SwaggerUI.Themes/readme.txt
@@ -2,18 +2,11 @@
 ##   RELEASE NOTES   ##
  #-------------------#
 
-v2.0.0
+v2.1.0
 
-Breaking Changes:
-- Removed NoJsModernStyle in favor of ModernStyle, which now defaults to not loading JavaScript. See release notes: https://github.com/teociaps/SwaggerUI.Themes/releases/tag/v2.0.0
-
-Other Changes:
-- .NET 9 support!
-- Introducing Advanced Options! Follow the link down below to learn more
-- New Swagger UI feature: sticky operations (both classic and modern themes)
-- New Swagger UI feature: expand/collapse operations (modern themes only)
-- Now JS is loaded for custom styles with "modern" prefix from assembly
-- Fixes and enhancements
+Changes:
+- .NET 10 support!
+- .NET 6 & .NET 7 support dropped.
 
 
 More info: https://github.com/teociaps/SwaggerUI.Themes?tab=readme-ov-file#swaggeruithemes

--- a/src/NSwag.AspNetCore.Themes/NSwag.AspNetCore.Themes.csproj
+++ b/src/NSwag.AspNetCore.Themes/NSwag.AspNetCore.Themes.csproj
@@ -18,13 +18,13 @@
       Change theme to your Swagger API documentation in ASP.NET Core applications.
     </Description>
     <PackageTags>
-      extension;aspnetcore;swagger;swagger-ui;nswag;themes;dark-theme;modern
+      extension;aspnetcore;swagger;swagger-ui;nswag;themes;ui;dark-theme;modern
     </PackageTags>
     <IncludeBuildOutput>true</IncludeBuildOutput>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSwag.AspNetCore" Version="14.1.0" />
+    <PackageReference Include="NSwag.AspNetCore" Version="14.6.2" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NSwag.AspNetCore.Themes/readme.txt
+++ b/src/NSwag.AspNetCore.Themes/readme.txt
@@ -2,18 +2,11 @@
 ##   RELEASE NOTES   ##
  #-------------------#
 
-v2.0.0
+v2.1.0
 
-Breaking Changes:
-- Removed NoJsModernStyle in favor of ModernStyle, which now defaults to not loading JavaScript. See release notes: https://github.com/teociaps/SwaggerUI.Themes/releases/tag/v2.0.0
-
-Other Changes:
-- .NET 9 support!
-- Introducing Advanced Options! Follow the link down below to learn more
-- New Swagger UI feature: sticky operations (both classic and modern themes)
-- New Swagger UI feature: expand/collapse operations (modern themes only)
-- Now JS is loaded for custom styles with "modern" prefix from assembly
-- Fixes and enhancements
+Changes:
+- .NET 10 support!
+- .NET 6 & .NET 7 support dropped.
 
 
 More info: https://github.com/teociaps/SwaggerUI.Themes?tab=readme-ov-file#swaggeruithemes

--- a/tests/AspNetCore.SwaggerUI.Themes.Tests/AspNetCore.Swagger.Themes.Tests.csproj
+++ b/tests/AspNetCore.SwaggerUI.Themes.Tests/AspNetCore.Swagger.Themes.Tests.csproj
@@ -17,27 +17,22 @@
     <EmbeddedResource Include="SwaggerThemes\style.css" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.20" />
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
-  </ItemGroup>
-
   <ItemGroup>
-    <PackageReference Condition=" '$(TargetFramework)' == 'net9.0' " Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
+    <PackageReference Condition=" '$(TargetFramework)' == 'net10.0' " Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
+
+    <PackageReference Condition=" '$(TargetFramework)' == 'net9.0' " Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.11" />
 
     <PackageReference Condition=" '$(TargetFramework)' == 'net8.0' " Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
 
-    <PackageReference Condition=" '$(TargetFramework)' == 'net6.0' " Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.36" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Shouldly" Version="4.3.0" />
 
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="Shouldly" Version="4.2.1" />
-
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
This pull request introduces significant updates focused on modernizing the project by updating dependencies, dropping support for older .NET versions, and cleaning up documentation and sample code. The changes streamline the codebase for .NET 8, 9, and new .NET 10 support, while removing legacy support and outdated sample logic.